### PR TITLE
remove install script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "fileforg",
       "version": "1.0.1",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "util": "^0.12.5"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "dev": "node index.js",
-    "install": "npm i fileforg"
+    "dev": "node index.js"
   },
   "keywords": [
     "NeatFile",


### PR DESCRIPTION
The package that was latest published on npm had an 'install' script And running npm install on this module pulled the latest npm package So this caused a situation where the package will keep installing itself in itself until npm decides to kill it